### PR TITLE
feat: add prompt-based flow generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ initial_state = {"count": 0, "message": "", "done": False}
 final_state = runner.run(initial_state)
 ```
 
+## Prompt-to-Flow Generation
+
+You can create flow definitions directly from natural language using the
+`from_prompt` helper. This allows rapid prototyping of workflows without
+hand-writing JSON.
+
+```python
+import json
+from langchain_openai import ChatOpenAI
+from hobnob import from_prompt
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+flow = from_prompt("A workflow that greets a user and then asks for feedback", llm=llm)
+print(json.dumps(flow, indent=2))
+```
+
+### Refining a Flow
+
+The generated JSON can be refined by sending it back to `from_prompt` with
+additional instructions:
+
+```python
+refined = from_prompt(
+    "Add a final step that thanks the user and ends the session. "
+    "Here is the current flow:\n" + json.dumps(flow),
+    llm=llm,
+)
+```
+
 ## Step Types
 
 ### LLM Steps

--- a/examples/prompt_to_flow.py
+++ b/examples/prompt_to_flow.py
@@ -1,0 +1,24 @@
+"""CLI example for generating Hobnob flows from natural language prompts."""
+
+import argparse
+import json
+
+from langchain_openai import ChatOpenAI
+
+from hobnob import from_prompt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a Hobnob flow from a natural language description",
+    )
+    parser.add_argument("prompt", help="Description of the workflow to build")
+    args = parser.parse_args()
+
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    flow = from_prompt(args.prompt, llm=llm)
+    print(json.dumps(flow, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/hobnob/__init__.py
+++ b/hobnob/__init__.py
@@ -1,4 +1,5 @@
 from hobnob.core import FlowRunner
 from hobnob.routers import RouterRegistry, EvalRouter
+from hobnob.generation import from_prompt
 
-__all__ = ["FlowRunner", "RouterRegistry", "EvalRouter"]
+__all__ = ["FlowRunner", "RouterRegistry", "EvalRouter", "from_prompt"]

--- a/hobnob/core.py
+++ b/hobnob/core.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, Any, Callable, List
+from typing import Any, Dict, Optional
 from langgraph.graph import StateGraph, END
 from hobnob.executors import LLMStep, UserInputStep
 from hobnob.rendering import PromptRenderer

--- a/hobnob/executors.py
+++ b/hobnob/executors.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, Any, Protocol, Callable
+from typing import Any, Dict, Protocol
 from langchain_core.language_models import BaseChatModel
 from hobnob.rendering import PromptRenderer
 from hobnob.parsing import JsonParser

--- a/hobnob/generation.py
+++ b/hobnob/generation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+
+from .parsing import JsonParser
+
+
+def from_prompt(prompt: str, llm: Optional[BaseChatModel] = None) -> Dict[str, Any]:
+    """Generate a Hobnob flow definition from natural language.
+
+    Parameters
+    ----------
+    prompt:
+        Natural language description of the workflow.
+    llm:
+        Optional LangChain chat model. If omitted, ``ChatOpenAI`` is used.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Flow definition compatible with :class:`hobnob.core.FlowRunner`.
+    """
+    llm = llm or ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    system_prompt = (
+        "You convert natural language workflow descriptions into a JSON object "
+        "for the Hobnob framework. The JSON must contain 'system_prompt' (optional), "
+        "'steps' (list of step objects), 'transitions' (list of transitions), and "
+        "'initial_step'. Each step object requires a 'name' and may include 'type', "
+        "'context', 'instructions', 'output_format', 'examples', 'prompt', or 'question'. "
+        "Transitions need 'from' and 'to' (null to end) and optional 'condition'. "
+        "Return ONLY valid JSON without additional commentary."
+    )
+    result = llm.invoke([
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=prompt),
+    ])
+    return JsonParser().parse(result.content)

--- a/hobnob/parsing.py
+++ b/hobnob/parsing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-import json, re
+
+import json
+import re
 from typing import Any, Dict
 
 

--- a/hobnob/routers.py
+++ b/hobnob/routers.py
@@ -1,6 +1,6 @@
 # routers.py
 
-from typing import Protocol, Dict, Any, Optional
+from typing import Any, Dict, Protocol
 import jmespath
 
 class ConditionRouter(Protocol):


### PR DESCRIPTION
## Summary
- add `from_prompt` helper to convert natural language into Hobnob flow JSON
- expose new helper via package and provide CLI example
- document generating and refining flows through prompts

## Testing
- `ruff check hobnob examples`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a605813f30832ea0c7f61742f0d95e