### PR TITLE
Add executor registry and sample executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ initial_state = {"count": 0, "message": "", "done": False}
 final_state = runner.run(initial_state)
 ```
 
+## Prompt-to-Flow Generation
+
+You can create flow definitions directly from natural language using the
+`from_prompt` helper. This allows rapid prototyping of workflows without
+hand-writing JSON.
+
+```python
+import json
+from langchain_openai import ChatOpenAI
+from hobnob import from_prompt
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+flow = from_prompt("A workflow that greets a user and then asks for feedback", llm=llm)
+print(json.dumps(flow, indent=2))
+```
+
+### Refining a Flow
+
+The generated JSON can be refined by sending it back to `from_prompt` with
+additional instructions:
+
+```python
+refined = from_prompt(
+    "Add a final step that thanks the user and ends the session. "
+    "Here is the current flow:\n" + json.dumps(flow),
+    llm=llm,
+)
+```
+
 ## Step Types
 
 ### LLM Steps
@@ -98,6 +127,47 @@ Interactive steps that prompt the user for input:
     "type": "user_input",
     "question": "Would you like to continue? (yes/no): "
 }
+```
+
+### Web Search Steps
+Built-in executor that performs a DuckDuckGo query and stores the summary in state:
+
+```python
+{
+    "name": "lookup_topic",
+    "type": "web_search",
+    "query_key": "topic",        # read query from state["topic"]
+    "result_key": "summary"       # store results in state["summary"]
+}
+```
+
+### API Call Steps
+Generic HTTP request executor:
+
+```python
+{
+    "name": "get_joke",
+    "type": "api_call",
+    "url": "https://api.chucknorris.io/jokes/random",
+    "result_key": "joke"
+}
+```
+
+### Custom Executors
+Register domain-specific step types using the `ExecutorRegistry`:
+
+```python
+from hobnob import ExecutorRegistry
+
+def add_one_factory(cfg, _runner):
+    def _step(state):
+        return {**state, "n": state["n"] + 1}
+    return _step
+
+ExecutorRegistry.register("add_one", add_one_factory)
+
+# Then reference it in your flow definition:
+{"name": "bump", "type": "add_one"}
 ```
 
 ## Flow Configuration

--- a/examples/prompt_to_flow.py
+++ b/examples/prompt_to_flow.py
@@ -1,0 +1,24 @@
+"""CLI example for generating Hobnob flows from natural language prompts."""
+
+import argparse
+import json
+
+from langchain_openai import ChatOpenAI
+
+from hobnob import from_prompt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a Hobnob flow from a natural language description",
+    )
+    parser.add_argument("prompt", help="Description of the workflow to build")
+    args = parser.parse_args()
+
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    flow = from_prompt(args.prompt, llm=llm)
+    print(json.dumps(flow, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/hobnob/__init__.py
+++ b/hobnob/__init__.py
@@ -1,4 +1,12 @@
 from hobnob.core import FlowRunner
 from hobnob.routers import RouterRegistry, EvalRouter
+from hobnob.executors import ExecutorRegistry
+from hobnob.generation import from_prompt
 
-__all__ = ["FlowRunner", "RouterRegistry", "EvalRouter"]
+__all__ = [
+    "FlowRunner",
+    "RouterRegistry",
+    "EvalRouter",
+    "ExecutorRegistry",
+    "from_prompt",
+]

--- a/hobnob/core.py
+++ b/hobnob/core.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
-from typing import Dict, Any, Callable, List
-from langgraph.graph import StateGraph, END
-from hobnob.executors import LLMStep, UserInputStep
-from hobnob.rendering import PromptRenderer
-from hobnob.parsing import JsonParser
+from typing import Any, Dict, Optional
+from langgraph.graph import StateGraph, END  # type: ignore[import-not-found]
+from hobnob.executors import ExecutorRegistry
 from hobnob.routers import ConditionRouter, RouterRegistry
 
 class FlowRunner:
@@ -36,25 +34,16 @@ class FlowRunner:
         step_name = step_cfg["name"]
         stype = step_cfg.get("type", "llm")
         on_step = self.on_step
-        if stype == "user_input":
-            def _fn(state):
-                out = UserInputStep(step_cfg.get("question", "Continue? (yes/no): "))(state)
-                if on_step:
-                    on_step(step_name, out)
-                return out
-            return _fn
-        else:
-            def _fn(state):
-                out = LLMStep(
-                    step_cfg,
-                    self.llm,
-                    renderer=PromptRenderer(self.flow_def.get("system_prompt", "")),
-                    parser=JsonParser()
-                )(state)
-                if on_step:
-                    on_step(step_name, out)
-                return out
-            return _fn
+        factory = ExecutorRegistry.get(stype)
+        executor = factory(step_cfg, self)
+
+        def _fn(state):
+            out = executor(state)
+            if on_step:
+                on_step(step_name, out)
+            return out
+
+        return _fn
 
     def _build_graph(self):
         sg = StateGraph(self.state_schema)

--- a/hobnob/executors.py
+++ b/hobnob/executors.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from typing import Dict, Any, Protocol, Callable
-from langchain_core.language_models import BaseChatModel
+from typing import Any, Callable, Dict, Protocol
+from langchain_core.language_models import BaseChatModel  # type: ignore[import-not-found]
 from hobnob.rendering import PromptRenderer
 from hobnob.parsing import JsonParser
+import requests  # type: ignore[import]
 
 
 class Executor(Protocol):
@@ -36,3 +37,96 @@ class UserInputStep:
             if ans in ("yes", "no"):
                 return {**state, "user_continue": ans}
             print("Please answer 'yes' or 'no'.")
+
+
+class ExecutorRegistry:
+    """Registry for creating step executors by name."""
+
+    _executors: Dict[str, Callable[[Dict[str, Any], Any], Executor]] = {}
+
+    @classmethod
+    def register(
+        cls, name: str, factory: Callable[[Dict[str, Any], Any], Executor]
+    ) -> None:
+        cls._executors[name] = factory
+
+    @classmethod
+    def get(cls, name: str) -> Callable[[Dict[str, Any], Any], Executor]:
+        try:
+            return cls._executors[name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown executor type: {name}") from exc
+
+
+def _llm_factory(cfg: Dict[str, Any], runner: Any) -> Executor:
+    return LLMStep(
+        cfg,
+        runner.llm,
+        renderer=PromptRenderer(runner.flow_def.get("system_prompt", "")),
+        parser=JsonParser(),
+    )
+
+
+def _user_input_factory(cfg: Dict[str, Any], _runner: Any) -> Executor:
+    return UserInputStep(cfg.get("question", "Continue? (yes/no): "))
+
+
+class WebSearchStep:
+    """Example step that performs a DuckDuckGo search."""
+
+    def __init__(self, cfg: Dict[str, Any]):
+        self.query_key = cfg.get("query_key", "query")
+        self.result_key = cfg.get("result_key", "results")
+
+    def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        query = state.get(self.query_key, "")
+        if not query:
+            return state
+        resp = requests.get(
+            "https://api.duckduckgo.com/",
+            params={"q": query, "format": "json", "no_redirect": 1, "no_html": 1},
+        )
+        data = resp.json()
+        text = data.get("AbstractText") or ""
+        return {**state, self.result_key: text}
+
+
+def _web_search_factory(cfg: Dict[str, Any], _runner: Any) -> Executor:
+    return WebSearchStep(cfg)
+
+
+class APICallStep:
+    """Generic HTTP API call step."""
+
+    def __init__(self, cfg: Dict[str, Any]):
+        self.url = cfg["url"]
+        self.method = cfg.get("method", "get").lower()
+        self.params = cfg.get("params", {})
+        self.result_key = cfg.get("result_key", "api_result")
+
+    def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        params = {
+            k: v.format(**state) if isinstance(v, str) else v for k, v in self.params.items()
+        }
+        resp = requests.request(
+            self.method,
+            self.url,
+            params=params if self.method == "get" else None,
+            json=params if self.method != "get" else None,
+        )
+        try:
+            data: Any = resp.json()
+        except Exception:
+            data = resp.text
+        return {**state, self.result_key: data}
+
+
+def _api_call_factory(cfg: Dict[str, Any], _runner: Any) -> Executor:
+    return APICallStep(cfg)
+
+
+# Register built-in executors
+ExecutorRegistry.register("llm", _llm_factory)
+ExecutorRegistry.register("user_input", _user_input_factory)
+ExecutorRegistry.register("web_search", _web_search_factory)
+ExecutorRegistry.register("api_call", _api_call_factory)

--- a/hobnob/generation.py
+++ b/hobnob/generation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from langchain_core.language_models import BaseChatModel  # type: ignore[import-not-found]
+from langchain_core.messages import HumanMessage, SystemMessage  # type: ignore[import-not-found]
+from langchain_openai import ChatOpenAI  # type: ignore[import-not-found]
+
+from .parsing import JsonParser
+
+
+def from_prompt(prompt: str, llm: Optional[BaseChatModel] = None) -> Dict[str, Any]:
+    """Generate a Hobnob flow definition from natural language.
+
+    Parameters
+    ----------
+    prompt:
+        Natural language description of the workflow.
+    llm:
+        Optional LangChain chat model. If omitted, ``ChatOpenAI`` is used.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Flow definition compatible with :class:`hobnob.core.FlowRunner`.
+    """
+    llm = llm or ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    system_prompt = (
+        "You convert natural language workflow descriptions into a JSON object "
+        "for the Hobnob framework. The JSON must contain 'system_prompt' (optional), "
+        "'steps' (list of step objects), 'transitions' (list of transitions), and "
+        "'initial_step'. Each step object requires a 'name' and may include 'type', "
+        "'context', 'instructions', 'output_format', 'examples', 'prompt', or 'question'. "
+        "Transitions need 'from' and 'to' (null to end) and optional 'condition'. "
+        "Return ONLY valid JSON without additional commentary."
+    )
+    result = llm.invoke([
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=prompt),
+    ])
+    return JsonParser().parse(result.content)

--- a/hobnob/parsing.py
+++ b/hobnob/parsing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-import json, re
+
+import json
+import re
 from typing import Any, Dict
 
 

--- a/hobnob/routers.py
+++ b/hobnob/routers.py
@@ -1,7 +1,8 @@
 # routers.py
 
-from typing import Protocol, Dict, Any, Optional
-import jmespath
+from typing import Any, Dict, Protocol
+
+import jmespath  # type: ignore[import-untyped]
 
 class ConditionRouter(Protocol):
     def check(self, condition: str, state: Dict[str, Any]) -> bool: ...
@@ -27,7 +28,7 @@ class EvalRouter:
 # routers.py (continued)
 
 class RouterRegistry:
-    _routers = {
+    _routers: Dict[str, ConditionRouter] = {
         "jmespath": JMESPathRouter(),
         "eval": EvalRouter(),
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "langchain-openai>=0.3.28",
     "langgraph>=0.6.2",
     "python-dotenv>=1.1.1",
+    "requests>=2.32.3",
 ]
 
 [dependency-groups]

--- a/tests/test_builtin_executors.py
+++ b/tests/test_builtin_executors.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, TypedDict
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import hobnob.executors as executors
+from hobnob import FlowRunner
+
+
+class SearchState(TypedDict, total=False):
+    query: str
+    results: str
+
+
+def test_web_search_step(monkeypatch: Any) -> None:
+    def fake_get(url: str, params: Dict[str, Any]):
+        class Resp:
+            def json(self) -> Dict[str, Any]:
+                return {"AbstractText": "summary"}
+
+        return Resp()
+
+    monkeypatch.setattr(executors.requests, "get", fake_get)
+
+    flow_def = {
+        "steps": [
+            {"name": "search", "type": "web_search", "query_key": "query", "result_key": "results"}
+        ],
+        "transitions": [{"from": "search", "to": None}],
+        "initial_step": "search",
+    }
+
+    runner = FlowRunner(flow_def, llm=None, state_schema=SearchState)
+    result = runner.run({"query": "python"})
+
+    assert result["results"] == "summary"
+
+
+class APIState(TypedDict, total=False):
+    joke: Any
+
+
+def test_api_call_step(monkeypatch: Any) -> None:
+    def fake_request(
+        method: str,
+        url: str,
+        params: Dict[str, Any] | None = None,
+        json: Dict[str, Any] | None = None,
+    ):
+        class Resp:
+            def json(self) -> Dict[str, Any]:
+                return {"joke": "funny"}
+
+        return Resp()
+
+    monkeypatch.setattr(executors.requests, "request", fake_request)
+
+    flow_def = {
+        "steps": [
+            {"name": "joke", "type": "api_call", "url": "https://example.com", "result_key": "joke"}
+        ],
+        "transitions": [{"from": "joke", "to": None}],
+        "initial_step": "joke",
+    }
+
+    runner = FlowRunner(flow_def, llm=None, state_schema=APIState)
+    result = runner.run({})
+
+    assert result["joke"] == {"joke": "funny"}
+

--- a/tests/test_executor_registry.py
+++ b/tests/test_executor_registry.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict, TypedDict
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from hobnob import ExecutorRegistry, FlowRunner
+
+
+class State(TypedDict):
+    n: int
+
+
+def test_custom_executor_registration() -> None:
+    def add_one_factory(_cfg: Dict[str, Any], _runner: Any):
+        def _step(state: Dict[str, Any]) -> Dict[str, Any]:
+            return {**state, "n": state["n"] + 1}
+
+        return _step
+
+    ExecutorRegistry.register("add_one", add_one_factory)
+
+    flow_def = {
+        "steps": [{"name": "inc", "type": "add_one"}],
+        "transitions": [{"from": "inc", "to": None}],
+        "initial_step": "inc",
+    }
+
+    runner = FlowRunner(flow_def, llm=None, state_schema=State)
+    result = runner.run({"n": 1})
+
+    assert result["n"] == 2
+


### PR DESCRIPTION
## Summary
- introduce `ExecutorRegistry` for pluggable step executors
- update `FlowRunner` to construct steps via the registry
- add built-in `web_search` and `api_call` executors and document usage
- expose `from_prompt` helper and add tests for built-in executors

## Testing
- `ruff check hobnob tests`
- `mypy hobnob`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60584ff2c832e9ae31bb258e8040b